### PR TITLE
Fix code scanning alert no. 1: Use of externally-controlled format string

### DIFF
--- a/src/views/admin/approve-documents.vue
+++ b/src/views/admin/approve-documents.vue
@@ -268,7 +268,7 @@ export default {
   },
 
   created() {
-    console.log(this.type, '>>>>>>>>>')
+    console.log('%s >>>>>>>>>', this.type)
     if(this.type == 'verified') {
       this.getVerifiedUsers();
     }


### PR DESCRIPTION
Fixes [https://github.com/khorramk/nikahhelp-vue3/security/code-scanning/1](https://github.com/khorramk/nikahhelp-vue3/security/code-scanning/1)

To fix the problem, we should ensure that the user-provided value `this.type` is safely included in the `console.log` statement. This can be achieved by using a `%s` specifier in the format string and passing `this.type` as a separate argument. This approach ensures that any format specifiers in the user input are treated as plain text.

- Modify the `console.log` statement on line 271 to use a format string with a `%s` specifier.
- Pass `this.type` as a separate argument to `console.log`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
